### PR TITLE
updated the "outputPath" in the method SigningHelper.SignAssembly met…

### DIFF
--- a/src/Signature.Core/PackageSigner.cs
+++ b/src/Signature.Core/PackageSigner.cs
@@ -81,7 +81,7 @@ namespace Signature.Core
                     {
                         signedPackage = true;
 
-                        SigningHelper.SignAssembly(tempPath, keyPath ?? string.Empty, tempPath, keyPassword ?? string.Empty);
+                        SigningHelper.SignAssembly(tempPath, keyPath ?? string.Empty, Path.GetDirectoryName(tempPath), keyPassword ?? string.Empty);
 
                         using (var stream = new FileStream(tempPath, FileMode.OpenOrCreate, FileAccess.Read))
                         {


### PR DESCRIPTION
…hod to just send the full directory path rather than the full file path as Directory.CreateDirectory was failing within SignAssembly method.

Per MyGet ticket 3109, here is a suggested update.